### PR TITLE
cv2.drawChessboardCorners returns None

### DIFF
--- a/PyCalibration/src/calibrate.py
+++ b/PyCalibration/src/calibrate.py
@@ -73,7 +73,7 @@ def main():
             if found:
                 term = (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_COUNT, 30, 0.1)
                 corners2 = cv2.cornerSubPix(gray, corner, (5,5), (-1,-1), term)
-                im = cv2.drawChessboardCorners(im, pattern_size, corners2, found)
+                cv2.drawChessboardCorners(im, pattern_size, corners2, found)
                 img_points.append(corner.reshape(-1, 2))
                 obj_points.append(pattern_points)
             if not found:


### PR DESCRIPTION
This would cause the following error when setting up a new camera:

```
OpenCV Error: Assertion failed (ssize.area() > 0) in resize, file /build/buildd/opencv-2.4.8+dfsg1/modules/imgproc/src/imgwarp.cpp, line 1824
Traceback (most recent call last):
  File "calibrate.py", line 113, in <module>
    main()
  File "calibrate.py", line 82, in main
    cv2.imshow("image", cv2.resize(im, (0,0), fx=0.5, fy=0.5))
cv2.error: /build/buildd/opencv-2.4.8+dfsg1/modules/imgproc/src/imgwarp.cpp:1824: error: (-215) ssize.area() > 0 in function resize
```
